### PR TITLE
Add argument for maximum number of pngs to save

### DIFF
--- a/R/Maaslin2.R
+++ b/R/Maaslin2.R
@@ -276,6 +276,17 @@ options <-
 options <-
     optparse::add_option(
         options,
+        c("-g", "--max_pngs"),
+        type = "double",
+        dest = "max_pngs",
+        default = args$max_pngs,
+        help = paste("The maximum number of scatterplots for signficant",
+                     " associations to save as png files [ Default: %default ]"
+        )
+    )
+options <-
+    optparse::add_option(
+        options,
         c("-e", "--cores"),
         type = "double",
         dest = "cores",

--- a/R/Maaslin2.R
+++ b/R/Maaslin2.R
@@ -93,6 +93,7 @@ args$standardize <- TRUE
 args$plot_heatmap <- TRUE
 args$heatmap_first_n <- 50
 args$plot_scatter <- TRUE
+args$max_pngs <- 10
 args$cores <- 1
 args$reference <- NULL
 
@@ -338,6 +339,7 @@ Maaslin2 <-
         cores = 1,
         plot_heatmap = TRUE,
         plot_scatter = TRUE,
+        max_pngs = 10,
         heatmap_first_n = 50,
         reference = NULL)
     {
@@ -1025,7 +1027,8 @@ Maaslin2 <-
                 filtered_data,
                 significant_results_file,
                 output,
-                figures_folder)
+                figures_folder,
+                max_pngs)
         }
         
         return(fit_data)
@@ -1073,6 +1076,7 @@ if (identical(environment(), globalenv()) &&
             current_args$cores,
             current_args$plot_heatmap,
             current_args$plot_scatter,
+            current_args$max_pngs,
             current_args$heatmap_first_n,
             current_args$reference
         )

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Options:
         associations [ Default: TRUE ]
         
     -g MAX_PNGS, --max_pngs=MAX_PNGS
-        The maximum number of scatterplots for signficant  associations 
+        The maximum number of scatterplots for signficant associations 
         to save as png files [ Default: 10 ]
 
     -e CORES, --cores=CORES

--- a/README.md
+++ b/README.md
@@ -253,6 +253,10 @@ Options:
     -o PLOT_SCATTER, --plot_scatter=PLOT_SCATTER
         Generate scatter plots for the significant
         associations [ Default: TRUE ]
+        
+    -g MAX_PNGS, --max_pngs=MAX_PNGS
+        The maximum number of scatterplots for signficant  associations 
+        to save as png files [ Default: 10 ]
 
     -e CORES, --cores=CORES
         The number of R processes to run in parallel

--- a/man/Maaslin2.Rd
+++ b/man/Maaslin2.Rd
@@ -88,6 +88,10 @@ Maaslin2(
     \item{plot_scatter}{
     Generate scatter plots for the significant associations.
 }
+    \item{max_pngs}{
+    Set the maximum number of scatterplots for signficant associations 
+    to save as png files.  
+}
     \item{cores}{
     The number of R processes to run in parallel.
 }

--- a/vignettes/maaslin2.Rmd
+++ b/vignettes/maaslin2.Rmd
@@ -258,6 +258,10 @@ Options:
     -o PLOT_SCATTER, --plot_scatter=PLOT_SCATTER
         Generate scatter plots for the significant
         associations [ Default: TRUE ]
+        
+    -g MAX_PNGS, --max_pngs=MAX_PNGS
+        The maximum number of scatterplots for signficant associations 
+        to save as png files [ Default: 10 ]
 
     -e CORES, --cores=CORES
         The number of R processes to run in parallel


### PR DESCRIPTION
Option to change number of pngs of scatterplots/boxplots saved to disk (in addition to pdf output) was previously only accessible by calling plotting function directly.  Add max_pngs as a command line and main maaslin2 function parameter to allow easier access to this.