### PR TITLE
Update output formatting

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -7,7 +7,7 @@ import("lpsymphony")
 import("optparse")
 importFrom("grDevices", "colorRampPalette", "dev.off", "pdf", "jpeg","png")
 importFrom("stats", "as.formula", "coef", "glm", "lm", "na.exclude",
-    "p.adjust", "update")
+    "p.adjust", "update", "relevel")
 importFrom("utils", "capture.output", "read.table", "write.table")
 importFrom("dplyr", "%>%")
 importFrom("stats", "sd", "na.omit")

--- a/R/Maaslin2.R
+++ b/R/Maaslin2.R
@@ -303,7 +303,7 @@ options <-
         type = "logical",
         dest = "save_models",
         default = args$save_models,
-        help = paste("Save the all full model objects",
+        help = paste("Save all full model objects",
                      " as an RData file [ Default: %default ]"
         )
     )

--- a/R/Maaslin2.R
+++ b/R/Maaslin2.R
@@ -391,6 +391,12 @@ Maaslin2 <-
             print("Creating output feature tables folder")
             dir.create(features_folder)
         }
+        
+        fits_folder <- file.path(output, "fits")
+        if (!file.exists(fits_folder)) {
+            print("Creating output fits folder")
+            dir.create(fits_folder)
+        }
 
         if (plot_heatmap || plot_scatter) {
             figures_folder <- file.path(output, "figures")
@@ -894,11 +900,11 @@ Maaslin2 <-
                     length(which(filtered_data_norm[, x[1]] > 0))
             )
         
-        #########################
-        # Write out the results #
-        #########################
+        ################################
+        # Write out the raw model fits #
+        ################################
         
-        fits_file = file.path(output, "fits.rds")
+        fits_file = file.path(fits_folder, "fits.rds")
         # remove residuals file if already exists (since residuals append)
         if (file.exists(fits_file)) {
             logging::logwarn(
@@ -910,7 +916,7 @@ Maaslin2 <-
         
         
         ##########################################
-        # write processed feature tables to file #
+        # Write processed feature tables to file #
         ##########################################
         
         filtered_file = file.path(features_folder, "filtered_data.tsv")
@@ -944,10 +950,10 @@ Maaslin2 <-
         )
         
         ###########################
-        # write residuals to file #
+        # Write residuals to file #
         ###########################
         
-        residuals_file = file.path(output, "residuals.rds")
+        residuals_file = file.path(fits_folder, "residuals.rds")
         # remove residuals file if already exists (since residuals append)
         if (file.exists(residuals_file)) {
             logging::logwarn(
@@ -958,10 +964,10 @@ Maaslin2 <-
         saveRDS(fit_data$residuals, file = residuals_file)
         
         ###############################
-        # write fitted values to file #
+        # Write fitted values to file #
         ###############################
         
-        fitted_file = file.path(output, "fitted.rds")
+        fitted_file = file.path(fits_folder, "fitted.rds")
         # remove fitted file if already exists (since fitted append)
         if (file.exists(fitted_file)) {
           logging::logwarn(
@@ -971,12 +977,12 @@ Maaslin2 <-
         logging::loginfo("Writing fitted values to file %s", fitted_file)
         saveRDS(fit_data$fitted, file = fitted_file)
         
-        ########################################################
-        # write extracted random effects to file (if specified) #
-        ########################################################
+        #########################################################
+        # Write extracted random effects to file (if specified) #
+        #########################################################
         
         if (!is.null(random_effects)) {
-          ranef_file = file.path(output, "ranef.rds")
+          ranef_file = file.path(fits_folder, "ranef.rds")
           # remove ranef file if already exists (since ranef append)
           if (file.exists(ranef_file)) {
             logging::logwarn(
@@ -988,7 +994,7 @@ Maaslin2 <-
         }
         
         #############################
-        # write all results to file #
+        # Write all results to file #
         #############################
         
         results_file <- file.path(output, "all_results.tsv")
@@ -1028,7 +1034,7 @@ Maaslin2 <-
         )
         
         ###########################################
-        # write results passing threshold to file #
+        # Write results passing threshold to file #
         ###########################################
         
         significant_results <-

--- a/R/Maaslin2.R
+++ b/R/Maaslin2.R
@@ -905,13 +905,13 @@ Maaslin2 <-
         ################################
         
         fits_file = file.path(fits_folder, "fits.rds")
-        # remove residuals file if already exists (since residuals append)
+        # remove fits file if already exists (since fits append)
         if (file.exists(fits_file)) {
             logging::logwarn(
-                "Deleting existing residuals file: %s", fits_file)
+                "Deleting existing fits file: %s", fits_file)
             unlink(fits_file)
         }
-        logging::loginfo("Writing residuals to file %s", fits_file)
+        logging::loginfo("Writing fits to file %s", fits_file)
         saveRDS(fit_data$fits, file = fits_file)
         
         

--- a/R/Maaslin2.R
+++ b/R/Maaslin2.R
@@ -891,6 +891,20 @@ Maaslin2 <-
         # Write out the results #
         #########################
         
+        ###############################
+        # write filtered data to file #
+        ###############################
+        
+        filtered_file = file.path(output, "filtered_data.tsv")
+        logging::loginfo("Writing filtered data to file %s", filtered_file)
+        write.table(
+            data.frame("feature" = rownames(filtered_data), filtered_data), 
+            file = filtered_file, 
+            sep = "\t", 
+            quote = FALSE, 
+            row.names = FALSE
+            )
+        
         ###########################
         # write residuals to file #
         ###########################

--- a/R/Maaslin2.R
+++ b/R/Maaslin2.R
@@ -1164,6 +1164,7 @@ if (identical(environment(), globalenv()) &&
             current_args$plot_scatter,
             current_args$max_pngs,
             current_args$heatmap_first_n,
+            current_args$save_models,
             current_args$reference
         )
 }

--- a/R/Maaslin2.R
+++ b/R/Maaslin2.R
@@ -775,7 +775,7 @@ Maaslin2 <-
                                paste(as.character(mlevels), collapse=", "), ".", sep=""))   
                 } 
             } else {
-                stop("Error determining reference level for metadata. Please check that provided category has 2 or more non-NA values.")
+                stop("Provided categorical metadata has fewer than 2 unique, non-NA values.")
             }
         }
  

--- a/R/Maaslin2.R
+++ b/R/Maaslin2.R
@@ -385,14 +385,21 @@ Maaslin2 <-
             print("Creating output folder")
             dir.create(output)
         }
+        
+        features_folder <- file.path(output, "features")
+        if (!file.exists(features_folder)) {
+            print("Creating output feature tables folder")
+            dir.create(features_folder)
+        }
 
-        if (plot_heatmap || plot_scatter){
-            figures_folder <- file.path(output,"figures")
-        if (!file.exists(figures_folder)) {
-            print("Creating output figures folder")
-            dir.create(figures_folder)
+        if (plot_heatmap || plot_scatter) {
+            figures_folder <- file.path(output, "figures")
+            if (!file.exists(figures_folder)) {
+                print("Creating output figures folder")
+                dir.create(figures_folder)
+            }
         }
-        }
+    
         
         # create log file (write info to stdout and debug level to log file)
         # set level to finest so all log levels are reviewed
@@ -906,7 +913,7 @@ Maaslin2 <-
         # write processed feature tables to file #
         ##########################################
         
-        filtered_file = file.path(output, "filtered_data.tsv")
+        filtered_file = file.path(features_folder, "filtered_data.tsv")
         logging::loginfo("Writing filtered data to file %s", filtered_file)
         write.table(
             data.frame("feature" = rownames(filtered_data), filtered_data), 
@@ -916,7 +923,7 @@ Maaslin2 <-
             row.names = FALSE
             )
         
-        filtered_data_norm_file = file.path(output, "filtered_data_norm.tsv")
+        filtered_data_norm_file = file.path(features_folder, "filtered_data_norm.tsv")
         logging::loginfo("Writing filtered, normalized data to file %s", filtered_data_norm_file)
         write.table(
             data.frame("feature" = rownames(filtered_data_norm), filtered_data_norm), 
@@ -926,7 +933,7 @@ Maaslin2 <-
             row.names = FALSE
         )
         
-        filtered_data_norm_transformed_file = file.path(output, "filtered_data_norm_transformed.tsv")
+        filtered_data_norm_transformed_file = file.path(features_folder, "filtered_data_norm_transformed.tsv")
         logging::loginfo("Writing filtered, normalized, transformed data to file %s", filtered_data_norm_transformed_file)
         write.table(
             data.frame("feature" = rownames(filtered_data_norm_transformed), filtered_data_norm_transformed), 

--- a/R/Maaslin2.R
+++ b/R/Maaslin2.R
@@ -276,6 +276,17 @@ options <-
 options <-
     optparse::add_option(
         options,
+        c("-g", "--max_pngs"),
+        type = "double",
+        dest = "max_pngs",
+        default = args$max_pngs,
+        help = paste("The maximum number of scatterplots for signficant",
+                     " associations to save as png files [ Default: %default ]"
+        )
+    )
+options <-
+    optparse::add_option(
+        options,
         c("-e", "--cores"),
         type = "double",
         dest = "cores",

--- a/R/Maaslin2.R
+++ b/R/Maaslin2.R
@@ -902,9 +902,9 @@ Maaslin2 <-
         saveRDS(fit_data$fits, file = fits_file)
         
         
-        ###############################
-        # write filtered data to file #
-        ###############################
+        ##########################################
+        # write processed feature tables to file #
+        ##########################################
         
         filtered_file = file.path(output, "filtered_data.tsv")
         logging::loginfo("Writing filtered data to file %s", filtered_file)
@@ -915,6 +915,26 @@ Maaslin2 <-
             quote = FALSE, 
             row.names = FALSE
             )
+        
+        filtered_data_norm_file = file.path(output, "filtered_data_norm.tsv")
+        logging::loginfo("Writing filtered, normalized data to file %s", filtered_data_norm_file)
+        write.table(
+            data.frame("feature" = rownames(filtered_data_norm), filtered_data_norm), 
+            file = filtered_data_norm_file, 
+            sep = "\t", 
+            quote = FALSE, 
+            row.names = FALSE
+        )
+        
+        filtered_data_norm_transformed_file = file.path(output, "filtered_data_norm_transformed.tsv")
+        logging::loginfo("Writing filtered, normalized, transformed data to file %s", filtered_data_norm_transformed_file)
+        write.table(
+            data.frame("feature" = rownames(filtered_data_norm_transformed), filtered_data_norm_transformed), 
+            file = filtered_data_norm_transformed_file, 
+            sep = "\t", 
+            quote = FALSE, 
+            row.names = FALSE
+        )
         
         ###########################
         # write residuals to file #

--- a/R/Maaslin2.R
+++ b/R/Maaslin2.R
@@ -93,6 +93,7 @@ args$standardize <- TRUE
 args$plot_heatmap <- TRUE
 args$heatmap_first_n <- 50
 args$plot_scatter <- TRUE
+args$max_pngs <- 10
 args$cores <- 1
 args$reference <- NULL
 
@@ -338,6 +339,7 @@ Maaslin2 <-
         cores = 1,
         plot_heatmap = TRUE,
         plot_scatter = TRUE,
+        max_pngs = 10,
         heatmap_first_n = 50,
         reference = NULL)
     {
@@ -1025,7 +1027,8 @@ Maaslin2 <-
                 filtered_data,
                 significant_results_file,
                 output,
-                figures_folder)
+                figures_folder,
+                max_pngs)
         }
         
         return(fit_data)
@@ -1073,6 +1076,7 @@ if (identical(environment(), globalenv()) &&
             current_args$cores,
             current_args$plot_heatmap,
             current_args$plot_scatter,
+            current_args$max_pngs,
             current_args$heatmap_first_n,
             current_args$reference
         )

--- a/R/Maaslin2.R
+++ b/R/Maaslin2.R
@@ -891,6 +891,17 @@ Maaslin2 <-
         # Write out the results #
         #########################
         
+        fits_file = file.path(output, "fits.rds")
+        # remove residuals file if already exists (since residuals append)
+        if (file.exists(fits_file)) {
+            logging::logwarn(
+                "Deleting existing residuals file: %s", fits_file)
+            unlink(fits_file)
+        }
+        logging::loginfo("Writing residuals to file %s", fits_file)
+        saveRDS(fit_data$fits, file = fits_file)
+        
+        
         ###############################
         # write filtered data to file #
         ###############################

--- a/R/Maaslin2.R
+++ b/R/Maaslin2.R
@@ -915,16 +915,17 @@ Maaslin2 <-
         # Write out the raw model fits #
         ################################
         
-        fits_file = file.path(fits_folder, "fits.rds")
-        # remove fits file if already exists (since fits append)
-        if (file.exists(fits_file)) {
-            logging::logwarn(
-                "Deleting existing fits file: %s", fits_file)
-            unlink(fits_file)
+        if (save_models) {
+            model_file = file.path(fits_folder, "models.rds")
+            # remove models file if already exists (since models append)
+            if (file.exists(model_file)) {
+                logging::logwarn(
+                    "Deleting existing model objects file: %s", model_file)
+                unlink(model_file)
+            }
+            logging::loginfo("Writing model objects to file %s", model_file)
+            saveRDS(fit_data$fits, file = model_file)   
         }
-        logging::loginfo("Writing fits to file %s", fits_file)
-        saveRDS(fit_data$fits, file = fits_file)
-        
         
         ##########################################
         # Write processed feature tables to file #

--- a/R/Maaslin2.R
+++ b/R/Maaslin2.R
@@ -296,7 +296,17 @@ options <-
             "run in parallel [ Default: %default ]"
         )
     )
-
+options <-
+    optparse::add_option(
+        options,
+        c("-j", "--save_models"),
+        type = "logical",
+        dest = "save_models",
+        default = args$save_models,
+        help = paste("Save the all full model objects",
+                     " as an RData file [ Default: %default ]"
+        )
+    )
 options <-
     optparse::add_option(
         options,
@@ -341,6 +351,7 @@ Maaslin2 <-
         plot_scatter = TRUE,
         max_pngs = 10,
         heatmap_first_n = 50,
+        save_models = FALSE,
         reference = NULL)
     {
         # Allow for lower case variables

--- a/R/fit.R
+++ b/R/fit.R
@@ -253,8 +253,9 @@ fit.data <-
                       d<-as.vector(unlist(l))
                       names(d)<-unlist(lapply(l, row.names))
                       output$ranef<-d
-                      }
                     }
+                    output$fit <- fit
+                }
                 else
                   {
                     logging::logwarn(paste(
@@ -268,6 +269,7 @@ fit.data <-
                     output$residuals <- NA
                     output$fitted <- NA
                     if (!(is.null(random_effects_formula))) output$ranef <- NA
+                    output$fit <- NA
                   }
                 colnames(output$para) <- c('coef', 'stderr' , 'pval', 'name')
                 output$para$feature <- colnames(features)[x]
@@ -294,6 +296,12 @@ fit.data <-
             return(x$fitted)
           }))
         row.names(fitted) <- colnames(features)   
+        
+        fits <-
+          lapply(outputs, function(x) {
+            return(x$fit)
+          })
+        names(fits) <- colnames(features)   
         
         if (!(is.null(random_effects_formula))) {
           ranef <-
@@ -349,9 +357,9 @@ fit.data <-
         rownames(paras)<-NULL
         
         if (!(is.null(random_effects_formula))) {
-          return(list("results" = paras, "residuals" = residuals, "fitted" = fitted, "ranef" = ranef))
+          return(list("results" = paras, "residuals" = residuals, "fitted" = fitted, "fits" = fits, "ranef" = ranef))
         } else {
-          return(list("results" = paras, "residuals" = residuals, "fitted" = fitted))
+          return(list("results" = paras, "residuals" = residuals, "fitted" = fitted, "fits" = fits))
         }
     }        
           

--- a/R/viz.R
+++ b/R/viz.R
@@ -235,7 +235,8 @@ maaslin2_heatmap <-
                     treeheight_row = 0,
                     treeheight_col = 0,
                     display_numbers = matrix(ifelse(
-                        a > 0.0, "+", ifelse(a < 0.0, "-", "")), nrow(a))
+                        a > 0.0, "+", ifelse(a < 0.0, "-", "")), nrow(a)),
+                    silent = TRUE
                 )
         }, error = function(err) {
             logging::logerror("Unable to plot heatmap")

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Options:
         associations [ Default: TRUE ]
         
     -g MAX_PNGS, --max_pngs=MAX_PNGS
-        The maximum number of scatterplots for signficant  associations 
+        The maximum number of scatterplots for signficant associations 
         to save as png files [ Default: 10 ]
 
     -e CORES, --cores=CORES

--- a/README.md
+++ b/README.md
@@ -263,12 +263,11 @@ Options:
         [ Default: 1 ]
     
     -d REFERENCE, --reference=REFERENCE
-        The factor to use as a reference for a variable 
-        with more than two levels provided as a string 
-        of 'variable,reference' semi-colon delimited 
-        for multiple variables [ Default: NA ] 
-        NOTE: A space between the variable and reference
-        will not error but will cause an inaccurate result.
+        The factor to use as a reference level for a categorical variable 
+        provided as a string of 'variable,reference', semi-colon delimited for 
+        multiple variables. Not required if metadata is passed as a factor or 
+        for variables with less than two levels but can be set regardless.
+        [ Default: NA ] 
 
 ## Troubleshooting ##
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ MaAsLin2 generates two types of output files: data and visualization.
     * ``significant_results.tsv``
         * This file is a subset of the results in the first file.
         * It only includes associations with q-values <= to the threshold.
+    * ``features```
+        * This folder includes the filtered, normalized, and transformed versions of the input feature table if applicable.
+    * ``fits.rds``
+        * This file contains a list of lists with every model fit.
     * ``residuals.rds``
         * This file contains a data frame with residuals for each feature.
     * ``fitted.rds``

--- a/README.md
+++ b/README.md
@@ -127,8 +127,9 @@ MaAsLin2 generates two types of output files: data and visualization.
         * This folder includes the filtered, normalized, and transformed versions of the input feature table.
         * These steps are performed sequentially in the above order.
         * If an option is set such that a step does not change the data, the resulting table will still be output.
-    * ``fits.rds``
-        * This file contains a list of lists with every model fit.
+    * ``models.rds``
+        * This file contains a list with every model fit object.
+        * It will only be generated if save_models is set to TRUE.
     * ``residuals.rds``
         * This file contains a data frame with residuals for each feature.
     * ``fitted.rds``
@@ -214,8 +215,7 @@ Options:
         is detected at minimum abundance [ Default: 0.1 ]
 
     -b MIN_VARIANCE, --min_variance=MIN_VARIANCE
-       Keep features with variance greater than
-       [ Default: 0.0 ]
+       Keep features with variance greater than [ Default: 0.0 ]
 
     -s MAX_SIGNIFICANCE, --max_significance=MAX_SIGNIFICANCE
         The q-value threshold for significance [ Default: 0.25 ]
@@ -267,6 +267,9 @@ Options:
     -e CORES, --cores=CORES
         The number of R processes to run in parallel
         [ Default: 1 ]
+        
+    -j SAVE_MODELS --save_models=SAVE_MODELS
+        Save all full model objects as an RData file [ Default: FALSE ]
     
     -d REFERENCE, --reference=REFERENCE
         The factor to use as a reference level for a categorical variable 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ MaAsLin2 generates two types of output files: data and visualization.
         * This file is a subset of the results in the first file.
         * It only includes associations with q-values <= to the threshold.
     * ``features```
-        * This folder includes the filtered, normalized, and transformed versions of the input feature table if applicable.
+        * This folder includes the filtered, normalized, and transformed versions of the input feature table.
+        * These steps are performed sequentially in the above order.
+        * If an option is set such that a step does not change the data, the resulting table will still be output.
     * ``fits.rds``
         * This file contains a list of lists with every model fit.
     * ``residuals.rds``

--- a/README.md
+++ b/README.md
@@ -253,6 +253,10 @@ Options:
     -o PLOT_SCATTER, --plot_scatter=PLOT_SCATTER
         Generate scatter plots for the significant
         associations [ Default: TRUE ]
+        
+    -g MAX_PNGS, --max_pngs=MAX_PNGS
+        The maximum number of scatterplots for signficant  associations 
+        to save as png files [ Default: 10 ]
 
     -e CORES, --cores=CORES
         The number of R processes to run in parallel

--- a/man/Maaslin2.Rd
+++ b/man/Maaslin2.Rd
@@ -33,6 +33,7 @@ Maaslin2(
     plot_scatter = TRUE,
     max_pngs = 10,
     heatmap_first_n = 50,
+    save_models = FALSE,
     reference = NULL
 )
 }
@@ -95,6 +96,9 @@ Maaslin2(
 }
     \item{cores}{
     The number of R processes to run in parallel.
+}
+    \item{save_models}{
+    Save the full model outputs to an RData file.
 }
     \item{reference}{
     The factor to use as a reference for a variable with more than two levels

--- a/man/Maaslin2.Rd
+++ b/man/Maaslin2.Rd
@@ -31,6 +31,7 @@ Maaslin2(
     cores = 1,
     plot_heatmap = TRUE,
     plot_scatter = TRUE,
+    max_pngs = 10,
     heatmap_first_n = 50,
     reference = NULL
 )

--- a/man/Maaslin2.Rd
+++ b/man/Maaslin2.Rd
@@ -88,6 +88,10 @@ Maaslin2(
     \item{plot_scatter}{
     Generate scatter plots for the significant associations.
 }
+    \item{max_pngs}{
+    Set the maximum number of scatterplots for signficant associations 
+    to save as png files.  
+}
     \item{cores}{
     The number of R processes to run in parallel.
 }

--- a/vignettes/maaslin2.Rmd
+++ b/vignettes/maaslin2.Rmd
@@ -258,6 +258,10 @@ Options:
     -o PLOT_SCATTER, --plot_scatter=PLOT_SCATTER
         Generate scatter plots for the significant
         associations [ Default: TRUE ]
+        
+    -g MAX_PNGS, --max_pngs=MAX_PNGS
+        The maximum number of scatterplots for signficant associations 
+        to save as png files [ Default: 10 ]
 
     -e CORES, --cores=CORES
         The number of R processes to run in parallel

--- a/vignettes/maaslin2.Rmd
+++ b/vignettes/maaslin2.Rmd
@@ -128,7 +128,9 @@ MaAsLin2 generates two types of output files: data and visualization.
         * This file is a subset of the results in the first file.
         * It only includes associations with q-values <= to the threshold.
     * ``features```
-        * This folder includes the filtered, normalized, and transformed versions of the input feature table if applicable.
+        * This folder includes the filtered, normalized, and transformed versions of the input feature table.
+        * These steps are performed sequentially in the above order.
+        * If an option is set such that a step does not change the data, the resulting table will still be output.
     * ``fits.rds``
         * This file contains a list of lists with every model fit.
     * ``residuals.rds``

--- a/vignettes/maaslin2.Rmd
+++ b/vignettes/maaslin2.Rmd
@@ -127,6 +127,10 @@ MaAsLin2 generates two types of output files: data and visualization.
     * ``significant_results.tsv``
         * This file is a subset of the results in the first file.
         * It only includes associations with q-values <= to the threshold.
+    * ``features```
+        * This folder includes the filtered, normalized, and transformed versions of the input feature table if applicable.
+    * ``fits.rds``
+        * This file contains a list of lists with every model fit.
     * ``residuals.rds``
         * This file contains a data frame with residuals for each feature.
     * ``fitted.rds``

--- a/vignettes/maaslin2.Rmd
+++ b/vignettes/maaslin2.Rmd
@@ -131,8 +131,9 @@ MaAsLin2 generates two types of output files: data and visualization.
         * This folder includes the filtered, normalized, and transformed versions of the input feature table.
         * These steps are performed sequentially in the above order.
         * If an option is set such that a step does not change the data, the resulting table will still be output.
-    * ``fits.rds``
-        * This file contains a list of lists with every model fit.
+    * ``models.rds``
+        * This file contains a list with every model fit object.
+        * It will only be generated if save_models is set to TRUE.
     * ``residuals.rds``
         * This file contains a data frame with residuals for each feature.
     * ``fitted.rds``
@@ -219,8 +220,7 @@ Options:
         is detected at minimum abundance [ Default: 0.1 ]
 
     -b MIN_VARIANCE, --min_variance=MIN_VARIANCE
-        Keep features with variance greater than
-	[ Default: 0.0 ]
+        Keep features with variance greater than [ Default: 0.0 ]
 
     -s MAX_SIGNIFICANCE, --max_significance=MAX_SIGNIFICANCE
         The q-value threshold for significance [ Default: 0.25 ]
@@ -272,6 +272,9 @@ Options:
     -e CORES, --cores=CORES
         The number of R processes to run in parallel
         [ Default: 1 ]
+        
+    -j SAVE_MODELS --save_models=SAVE_MODELS
+        Save all full model objects as an RData file [ Default: FALSE ]
 
     -d REFERENCE, --reference=REFERENCE
         The factor to use as a reference level for a categorical variable 

--- a/vignettes/maaslin2.Rmd
+++ b/vignettes/maaslin2.Rmd
@@ -268,10 +268,11 @@ Options:
         [ Default: 1 ]
 
     -d REFERENCE, --reference=REFERENCE
-        The factor to use as a reference for a variable 
-        with more than two levels provided as a string  
-        of 'variable,reference' semi-colon delimited 
-        for multiple variables [ Default: NA ] 
+        The factor to use as a reference level for a categorical variable 
+        provided as a string of 'variable,reference', semi-colon delimited for 
+        multiple variables. Not required if metadata is passed as a factor or 
+        for variables with less than two levels but can be set regardless.
+        [ Default: NA ] 
 
 ## Troubleshooting ##
 


### PR DESCRIPTION
This saves the filtered, normalized, and transformed feature tables to files as requested by several users.  It also saves all of the fit objects in a file.  This can be useful, but is a relatively large file to save, so let me know how you want to handle it (as is, make it an argument to save, or remove this feature?).  

Some minor restructuring of the folders outputs were saved in was done, though I think it could still be cleaner by saving the pdf results in a "figures" folder and moving the saved pngs to "pngs".  

Also fixed a longstanding bug where an extra copy of the heatmap was saved when calling from the command line.