### PR TITLE
fix: make correction method input case agnostic

### DIFF
--- a/R/Maaslin2.R
+++ b/R/Maaslin2.R
@@ -358,7 +358,9 @@ Maaslin2 <-
         normalization <- toupper(normalization)
         transform <- toupper(transform)
         analysis_method <- toupper(analysis_method)
-        correction <- toupper(correction)
+        
+        # Match variable ignoring case then set correctly as required for p.adjust
+        correction <- correction_choices[match(toupper(correction), toupper(correction_choices))]
 
         #################################################################
         # Read in the data and metadata, create output folder, init log #


### PR DESCRIPTION
Setting correction = bonferroni was failing because previous code coerced all arguments into upper-case.  Unlike other variables though, p-value correction is case sensitive because of p.adjust function behavior, so we need to account for that instead of always making uppercase.  