### PR TITLE
Check for normalization when using AST

### DIFF
--- a/R/Maaslin2.R
+++ b/R/Maaslin2.R
@@ -358,7 +358,9 @@ Maaslin2 <-
         normalization <- toupper(normalization)
         transform <- toupper(transform)
         analysis_method <- toupper(analysis_method)
-        correction <- toupper(correction)
+        
+        # Match variable ignoring case then set correctly as required for p.adjust
+        correction <- correction_choices[match(toupper(correction), toupper(correction_choices))]
 
         #################################################################
         # Read in the data and metadata, create output folder, init log #

--- a/R/utility_scripts.R
+++ b/R/utility_scripts.R
@@ -186,7 +186,15 @@ TMMnorm = function(features) {
 
 # Arc Sine Square Root Transformation
 AST <- function(x) {
-    return(sign(x) * asin(sqrt(abs(x))))
+    y <- sign(x) * asin(sqrt(abs(x)))
+    if(any(is.na(y))) {
+        logging::logerror(
+            paste0("AST transform is only valid for values between -1 and 1. ",
+                   "Please select an appropriate normalization option or ",
+                   "normalize your data prior to running."))
+        stop()
+    }
+    return(y)
 }
 
 ########################


### PR DESCRIPTION
AST transform doesn't work for values > 1, but normalization = "NONE" is considered a valid option, so users can easily supply values out of range.  The error message thrown for this previously was confusing.  This makes it more clear where the problem is and what to do.  

Let me know if this message makes sense.  The main reason it is encountered is because count data is supplied rather than relative abundance, but conceivably a user could be doing something else.  It was suggested that data normalized to a value other than 1 (e.g. 100) be automatically re-normalized with a warning rather than an error, but this runs into some other issues, mainly that if the data is normalized then filtered, we wouldn't easily be able to tell the difference between this and non-normalized data.  