### PR TITLE
Feat/save plots

### DIFF
--- a/R/Maaslin2.R
+++ b/R/Maaslin2.R
@@ -303,8 +303,8 @@ options <-
         type = "logical",
         dest = "save_models",
         default = args$save_models,
-        help = paste("Save all full model objects",
-                     " as an RData file [ Default: %default ]"
+        help = paste("Return the full model outputs ",
+                     "and save to an RData file. [ Default: %default ]"
         )
     )
 options <-
@@ -897,6 +897,7 @@ Maaslin2 <-
                 formula = formula,
                 random_effects_formula = random_effects_formula,
                 correction = correction,
+                save_models = save_models,
                 cores = cores
             )
         

--- a/R/Maaslin2.R
+++ b/R/Maaslin2.R
@@ -96,6 +96,7 @@ args$plot_scatter <- TRUE
 args$max_pngs <- 10
 args$save_scatter <- FALSE
 args$cores <- 1
+args$save_models <- FALSE
 args$reference <- NULL
 
 ##############################
@@ -360,10 +361,10 @@ Maaslin2 <-
         standardize = TRUE,
         cores = 1,
         plot_heatmap = TRUE,
+        heatmap_first_n = 50,
         plot_scatter = TRUE,
         max_pngs = 10,
         save_scatter = FALSE,
-        heatmap_first_n = 50,
         save_models = FALSE,
         reference = NULL)
     {
@@ -1201,10 +1202,10 @@ if (identical(environment(), globalenv()) &&
             current_args$standardize,
             current_args$cores,
             current_args$plot_heatmap,
+            current_args$heatmap_first_n,
             current_args$plot_scatter,
             current_args$max_pngs,
             current_args$save_scatter,
-            current_args$heatmap_first_n,
             current_args$save_models,
             current_args$reference
         )

--- a/R/Maaslin2.R
+++ b/R/Maaslin2.R
@@ -94,6 +94,7 @@ args$plot_heatmap <- TRUE
 args$heatmap_first_n <- 50
 args$plot_scatter <- TRUE
 args$max_pngs <- 10
+args$save_scatter <- FALSE
 args$cores <- 1
 args$reference <- NULL
 
@@ -117,7 +118,7 @@ options <-
         dest = "min_abundance",
         default = args$min_abundance,
         help = paste0("The minimum abundance for each feature",
-            " [ Default: %default ]"
+            "[ Default: %default ]"
         )
     )
 options <-
@@ -129,7 +130,7 @@ options <-
         default = args$min_prevalence,
         help = paste0("The minimum percent of samples for which",
             "a feature is detected at minimum abundance",
-            " [ Default: %default ]"
+            "[ Default: %default ]"
         )
     )
 options <-
@@ -141,7 +142,7 @@ options <-
         default = args$min_variance,
         help = paste0("Keep features with variances",
             "greater than value",
-            " [ Default: %default ]"
+            "[ Default: %default ]"
         )
     )
 options <-
@@ -152,7 +153,7 @@ options <-
         dest = "max_significance",
         default = args$max_significance,
         help = paste0("The q-value threshold for significance",
-            " [ Default: %default ]"
+            "[ Default: %default ]"
         )
     )
 options <-
@@ -164,7 +165,7 @@ options <-
         default = args$normalization,
         help = paste(
             "The normalization method to apply",
-            " [ Default: %default ] [ Choices:",
+            "[ Default: %default ] [ Choices:",
             toString(normalization_choices),
             "]"
         )
@@ -204,7 +205,7 @@ options <-
         default = args$random_effects,
         help = paste("The random effects for the model, ",
             "comma-delimited for multiple effects",
-            " [ Default: none ]"
+            "[ Default: none ]"
         )
     )
 options <-
@@ -215,8 +216,8 @@ options <-
         dest = "fixed_effects",
         default = args$fixed_effects,
         help = paste("The fixed effects for the model,",
-            " comma-delimited for multiple effects",
-            " [ Default: all ]"
+            "comma-delimited for multiple effects",
+            "[ Default: all ]"
         )
     )
 options <-
@@ -227,7 +228,7 @@ options <-
         dest = "correction",
         default = args$correction,
         help = paste("The correction method for computing",
-            " the q-value [ Default: %default ]"
+            "the q-value [ Default: %default ]"
         )
     )
 options <-
@@ -238,7 +239,7 @@ options <-
         dest = "standardize",
         default = args$standardize,
         help = paste("Apply z-score so continuous metadata are on",
-            " the same scale [ Default: %default ]"
+            "the same scale [ Default: %default ]"
         )
     )
 options <-
@@ -248,7 +249,7 @@ options <-
         type = "logical",
         dest = "plot_heatmap",
         default = args$plot_heatmap,
-        help = paste("Generate a heatmap for the significant ",
+        help = paste("Generate a heatmap for the significant",
             "associations [ Default: %default ]"
         )
     )
@@ -259,7 +260,7 @@ options <-
         type = "double",
         dest = "heatmap_first_n",
         default = args$heatmap_first_n,
-        help = paste("In heatmap, plot top N features with significant ",
+        help = paste("In heatmap, plot top N features with significant",
             "associations [ Default: %default ]"
         )
     )
@@ -271,7 +272,7 @@ options <-
         dest = "plot_scatter",
         default = args$plot_scatter,
         help = paste("Generate scatter plots for the significant",
-            " associations [ Default: %default ]"
+            "associations [ Default: %default ]"
         )
     )
 options <-
@@ -282,7 +283,18 @@ options <-
         dest = "max_pngs",
         default = args$max_pngs,
         help = paste("The maximum number of scatterplots for signficant",
-                     " associations to save as png files [ Default: %default ]"
+                     "associations to save as png files [ Default: %default ]"
+        )
+    )
+options <-
+    optparse::add_option(
+        options,
+        c("-O", "--save_scatter"),
+        type = "logical",
+        dest = "save_scatter",
+        default = args$save_scatter,
+        help = paste("Save all scatter plot ggplot objects",
+                     "to an RData file [ Default: %default ]"
         )
     )
 options <-
@@ -304,7 +316,7 @@ options <-
         dest = "save_models",
         default = args$save_models,
         help = paste("Return the full model outputs ",
-                     "and save to an RData file. [ Default: %default ]"
+                     "and save to an RData file [ Default: %default ]"
         )
     )
 options <-
@@ -350,6 +362,7 @@ Maaslin2 <-
         plot_heatmap = TRUE,
         plot_scatter = TRUE,
         max_pngs = 10,
+        save_scatter = FALSE,
         heatmap_first_n = 50,
         save_models = FALSE,
         reference = NULL)
@@ -544,6 +557,11 @@ Maaslin2 <-
                     toString(valid_choice_method_transform)
                 )
             }
+        }
+        # check that plots are generated if to be saved
+        if (!plot_scatter && save_scatter) {
+            logging::logerror("Scatter plots cannot be saved if they are not plotted")
+            stop("Option not valid", call. = FALSE)
         }
         
         ###############################################################
@@ -1118,13 +1136,25 @@ Maaslin2 <-
                     "to output folder: %s"),
                 output
             )
-            maaslin2_association_plots(
+            saved_plots <- maaslin2_association_plots(
                 unfiltered_metadata,
                 filtered_data,
                 significant_results_file,
                 output,
                 figures_folder,
-                max_pngs)
+                max_pngs,
+                save_scatter)
+            if (save_scatter) {
+                scatter_file <- file.path(figures_folder, "scatter_plots.rds")
+                # remove plots file if already exists
+                if (file.exists(scatter_file)) {
+                    logging::logwarn(
+                        "Deleting existing scatter plot objects file: %s", scatter_file)
+                    unlink(scatter_file)
+                }
+                logging::loginfo("Writing scatter plot objects to file %s", scatter_file)
+                saveRDS(saved_plots, file = scatter_file)   
+            }
         }
         
         return(fit_data)
@@ -1173,6 +1203,7 @@ if (identical(environment(), globalenv()) &&
             current_args$plot_heatmap,
             current_args$plot_scatter,
             current_args$max_pngs,
+            current_args$save_scatter,
             current_args$heatmap_first_n,
             current_args$save_models,
             current_args$reference

--- a/R/fit.R
+++ b/R/fit.R
@@ -367,9 +367,9 @@ fit.data <-
         rownames(paras)<-NULL
         
         if (!(is.null(random_effects_formula))) {
-          return(list("results" = paras, "residuals" = residuals, "fitted" = fitted, "fits" = fits, "ranef" = ranef))
+          return(list("results" = paras, "residuals" = residuals, "fitted" = fitted, "ranef" = ranef, "fits" = fits))
         } else {
-          return(list("results" = paras, "residuals" = residuals, "fitted" = fitted, "fits" = fits))
+          return(list("results" = paras, "residuals" = residuals, "fitted" = fitted, "ranef" = NULL, "fits" = fits))
         }
     }        
           

--- a/R/fit.R
+++ b/R/fit.R
@@ -23,6 +23,7 @@ fit.data <-
         formula = NULL,
         random_effects_formula = NULL,
         correction = "BH",
+        save_models = FALSE,
         cores = 1) {
 
         # set the formula default to all fixed effects if not provided
@@ -254,7 +255,11 @@ fit.data <-
                       names(d)<-unlist(lapply(l, row.names))
                       output$ranef<-d
                     }
-                    output$fit <- fit
+                    if (save_models) {
+                      output$fit <- fit
+                    } else {
+                      output$fit <- NA
+                    }
                 }
                 else
                   {
@@ -301,7 +306,12 @@ fit.data <-
           lapply(outputs, function(x) {
             return(x$fit)
           })
-        names(fits) <- colnames(features)   
+        names(fits) <- colnames(features)  
+        
+        # Return NULL rather than empty object if fits aren't saved
+        if (all(is.na(fits))) {
+          fits <- NULL
+        }
         
         if (!(is.null(random_effects_formula))) {
           ranef <-

--- a/R/viz.R
+++ b/R/viz.R
@@ -444,7 +444,7 @@ maaslin2_association_plots <-
                                 size = 2,
                                 fontface = "italic"
                             )
-                } else{
+                } else {
                     # if Metadata is categorical generate a boxplot
                     ### check if the variable is categorical
                     
@@ -526,10 +526,10 @@ maaslin2_association_plots <-
                 # keep all plots if desired
                 # or only keep plots to be printed to png
                 if (save_scatter) {
-                  saved_plots[[label]][[y_label]] <- temp_plot
+                  saved_plots[[label]][[count]] <- temp_plot
                 }
-                else if (count < max_pngs + 1) {
-                  saved_plots[[label]][[y_label]] <- temp_plot
+                else if (count <= max_pngs) {
+                  saved_plots[[label]][[count]] <- temp_plot
                 }
                 count <- count + 1
             }
@@ -544,12 +544,14 @@ maaslin2_association_plots <-
                         substr(basename(plot_file),1,nchar(basename(plot_file))-4),
                         "_",plot_number,".png"))
                 png(png_file, res = 300, width = 960, height = 960)
-                stdout <- capture.output(print(saved_plots[[label]][[max_pngs]]))
+                stdout <- capture.output(print(saved_plots[[label]][[plot_number]]))
                 dev.off()
             }
-            # remove plots saved for png generation
-            if (!save_scatter) {
-              saved_plots[[label]] <- NULL
+            # give plots informative names
+            if (save_scatter) {
+              names(saved_plots[[label]]) <- make.names(output_df_all[data_index, 'feature'], unique = TRUE)
+            } else {
+              saved_plots[[label]] <- NULL  # instead remove plots if only saved for png generation
             }
             metadata_number <- metadata_number + 1
         }

--- a/R/viz.R
+++ b/R/viz.R
@@ -290,7 +290,8 @@ maaslin2_association_plots <-
         output_results,
         write_to = './',
         figures_folder = './figures/',
-        max_pngs = 10)
+        max_pngs = 10,
+        save_scatter = FALSE)
     {
         #MaAslin2 scatter plot function and theme
         
@@ -352,9 +353,10 @@ maaslin2_association_plots <-
         metadata_labels <-
             unlist(metadata_types[!duplicated(metadata_types)])
         metadata_number <- 1
+        saved_plots <- list()
         
         for (label in metadata_labels) {
-            saved_plots <- vector('list', max_pngs)
+            saved_plots[[label]] <- list()
             # for file name replace any non alphanumeric with underscore
             plot_file <-
                 paste(
@@ -520,21 +522,36 @@ maaslin2_association_plots <-
                 stdout <- capture.output(print(temp_plot), type = "message")
                 if (length(stdout) > 0)
                     logging::logdebug(stdout)
-                if (count < max_pngs + 1)
-                    saved_plots[[count]] <- temp_plot
+                
+                # keep all plots if desired
+                # or only keep plots to be printed to png
+                if (save_scatter) {
+                  saved_plots[[label]][[y_label]] <- temp_plot
+                }
+                else if (count < max_pngs + 1) {
+                  saved_plots[[label]][[y_label]] <- temp_plot
+                }
                 count <- count + 1
             }
             dev.off()
+            
             # print the saved figures
-            for (plot_number in seq(1,max_pngs)) {
+            # this is done separately from pdf generation 
+            # because nested graphics devices cause problems in rmarkdown output
+            for (plot_number in seq(1, max_pngs)) {
                 png_file <- file.path(figures_folder,
                     paste0(
                         substr(basename(plot_file),1,nchar(basename(plot_file))-4),
                         "_",plot_number,".png"))
                 png(png_file, res = 300, width = 960, height = 960)
-                stdout <- capture.output(print(saved_plots[[plot_number]]))
+                stdout <- capture.output(print(saved_plots[[label]][[max_pngs]]))
                 dev.off()
+            }
+            # remove plots saved for png generation
+            if (!save_scatter) {
+              saved_plots[[label]] <- NULL
             }
             metadata_number <- metadata_number + 1
         }
+        return(saved_plots)
     }

--- a/README.md
+++ b/README.md
@@ -261,15 +261,19 @@ Options:
         associations [ Default: TRUE ]
         
     -g MAX_PNGS, --max_pngs=MAX_PNGS
-        The maximum number of scatterplots for signficant associations 
+        The maximum number of scatter plots for signficant associations 
         to save as png files [ Default: 10 ]
+    
+    -O SAVE_SCATTER, --save_scatter=SAVE_SCATTER
+        Save all scatter plot ggplot objects
+        to an RData file [ Default: FALSE ]
 
     -e CORES, --cores=CORES
         The number of R processes to run in parallel
         [ Default: 1 ]
         
     -j SAVE_MODELS --save_models=SAVE_MODELS
-        Return the full model outputs and save to an RData file.
+        Return the full model outputs and save to an RData file
         [ Default: FALSE ]
     
     -d REFERENCE, --reference=REFERENCE

--- a/README.md
+++ b/README.md
@@ -269,7 +269,8 @@ Options:
         [ Default: 1 ]
         
     -j SAVE_MODELS --save_models=SAVE_MODELS
-        Save all full model objects as an RData file [ Default: FALSE ]
+        Return the full model outputs and save to an RData file.
+        [ Default: FALSE ]
     
     -d REFERENCE, --reference=REFERENCE
         The factor to use as a reference level for a categorical variable 

--- a/man/Maaslin2.Rd
+++ b/man/Maaslin2.Rd
@@ -30,9 +30,10 @@ Maaslin2(
     standardize = TRUE,
     cores = 1,
     plot_heatmap = TRUE,
+    heatmap_first_n = 50,
     plot_scatter = TRUE,
     max_pngs = 10,
-    heatmap_first_n = 50,
+    save_scatter = FALSE,
     save_models = FALSE,
     reference = NULL
 )
@@ -91,8 +92,12 @@ Maaslin2(
     Generate scatter plots for the significant associations.
 }
     \item{max_pngs}{
-    Set the maximum number of scatterplots for signficant associations 
+    Set the maximum number of scatter plots for signficant associations 
     to save as png files.  
+}
+    \item{save_scatter}{
+    Save all scatter plot ggplot objects
+    to an RData file.
 }
     \item{cores}{
     The number of R processes to run in parallel.
@@ -107,7 +112,7 @@ Maaslin2(
 }
 }
 \value{
-    Data.frame containing the results from applying the model.
+    List containing the results from applying the model.
 }
 \author{
     Himel Mallick<himel.stat.iitk@gmail.com>,\cr

--- a/man/Maaslin2.Rd
+++ b/man/Maaslin2.Rd
@@ -98,7 +98,7 @@ Maaslin2(
     The number of R processes to run in parallel.
 }
     \item{save_models}{
-    Save the full model outputs to an RData file.
+    Return the full model outputs and save to an RData file.
 }
     \item{reference}{
     The factor to use as a reference for a variable with more than two levels

--- a/vignettes/maaslin2.Rmd
+++ b/vignettes/maaslin2.Rmd
@@ -269,15 +269,19 @@ Options:
         associations [ Default: TRUE ]
         
     -g MAX_PNGS, --max_pngs=MAX_PNGS
-        The maximum number of scatterplots for signficant associations 
+        The maximum number of scatter plots for signficant associations 
         to save as png files [ Default: 10 ]
+    
+    -O SAVE_SCATTER, --save_scatter=SAVE_SCATTER
+        Save all scatter plot ggplot objects
+        to an RData file [ Default: FALSE ]
 
     -e CORES, --cores=CORES
         The number of R processes to run in parallel
         [ Default: 1 ]
         
     -j SAVE_MODELS --save_models=SAVE_MODELS
-        Return the full model outputs and save to an RData file.
+        Return the full model outputs and save to an RData file
         [ Default: FALSE ]
 
     -d REFERENCE, --reference=REFERENCE

--- a/vignettes/maaslin2.Rmd
+++ b/vignettes/maaslin2.Rmd
@@ -277,7 +277,8 @@ Options:
         [ Default: 1 ]
         
     -j SAVE_MODELS --save_models=SAVE_MODELS
-        Save all full model objects as an RData file [ Default: FALSE ]
+        Return the full model outputs and save to an RData file.
+        [ Default: FALSE ]
 
     -d REFERENCE, --reference=REFERENCE
         The factor to use as a reference level for a categorical variable 


### PR DESCRIPTION
Add an option/parameter to export all scatter plot ggplot objects to a RData file.  Users have requested this so they can do things like facet the plots.  This file isn't particularly large because it's not storing the graphics, about feature table size  * number of fixed effects, but returning it as part of the maaslin output makes it very easy to accidentally print the whole thing and freeze up R.  

Models can also be returned which gives the user a lot more control over the output (made a couple tweaks though).  This is still returned as part of the list output (as well as saved) by the fit.data function, since no matter what it has to be stored in memory at some point if saved, and it doesn't clutter up the output as much.  It's actually bigger than the ggplot output, but should be somewhat linear with the size of the input files, so I'd never expect anything unusually large (more than a few MB).

A few points:  
Is the option -O okay to use?  We've gotten to the point where not using uppercase is tough.  
This can't currently save the plots without plotting them (generating pdfs etc).  It would take a more substantial re-write of the code to do this, though it's certainly possible and would make the overall structure of the package more cogent.  The idea ultimately would be make all the internal functions accessible and return output, while the main maaslin function (called from the command line or not) more directly simply stitches these together and writes outputs to files.
The plotting function is not exported, but this makes it more useful to do, especially if the above change is implemented in addition.  

Thanks!

- Tom