### PR TITLE
fix xtfrm warning message

### DIFF
--- a/R/viz.R
+++ b/R/viz.R
@@ -95,9 +95,9 @@ maaslin2_heatmap <-
         title_additional <- ""
         if (!is.na(first_n) & first_n > 0 & first_n < dim(df)[1]) {
             if (cell_value == 'coef') {
-                df <- df[order(-abs(df[cell_value])) , ]
+                df <- df[order(-abs(df[[cell_value]])) , ]
             } else{
-                df <- df[order(df[cell_value]), ]
+                df <- df[order(df[[cell_value]]), ]
             }
             # get the top n features with significant associations
             df_sub <- df[1:first_n,]


### PR DESCRIPTION
## Description
Add some brackets to fix the "cannot xtfrm data frames" warning message which is caused by calling order() on a data frame. df[cell_value] gives a data frame, while df[[cell_value]] correctly gives the contents of the cell_value column. I got identical results when testing with mtcars['mpg'] and mtcars[['mpg']], but I didn't thoroughly examine edge cases, NAs, etc.