### PR TITLE
Fix readme CL install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If only running from the command line, you do not need to install the MaAsLin2 p
 
 1. Download the source: [MaAsLin2.master.zip](https://github.com/biobakery/Maaslin2/archive/master.zip)
 2. Decompress the download: 
-    * ``$ tar xzvf Maaslin2-master.zip``
+    * ``$ unzip master.zip``
 3. Install the Bioconductor dependencies edgeR and metagenomeSeq. 
 4. Install the CRAN dependencies:
     * ``$ R -q -e "install.packages(c('lmerTest','pbapply','car','dplyr','vegan','chemometrics','ggplot2','pheatmap','hash','logging','data.table','MuMIn','glmmTMB','MASS','cplm','pscl'), repos='http://cran.r-project.org')"``


### PR DESCRIPTION
- File pointed to in the link is `master.zip`, rather than `Maaslin2-master.zip` (though the inflated directory looks like the later).
- Since it's a `zip` file rather than `.tar.gz`, `tar` doesn't work (at least not on Ubuntu). I got:

```
tar xvzf master.zip
gzip: stdin has more than one entry--rest ignored
tar: Child returned status 2
tar: Error is not recoverable: exiting now
```

But `unzip` worked just fine.