### PR TITLE
Add feature name to model fit warnings

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -232,7 +232,14 @@ fit.data <-
                             formula, 
                             data = dat_sub, 
                             na.action = na.exclude)
-                }, error = function(err) {
+                }, warning = function(w) { 
+                  message(paste("Feature", colnames(features)[x], ":", w))
+                  logging::logwarn(paste(
+                    "Fitting problem for feature", 
+                    x, 
+                    "a warning was issued"))
+                  return(fit1)
+                  }, error = function(err) {
                     fit1 <-
                         try({
                             model_function(


### PR DESCRIPTION
When the model fitting step throws warnings, it is unclear which models they are associated with.  Here, concatenate the name of the feature to the warning and add a line in the log file.  I've tried to keep with the current formatting of the logging.  Please let me know if you would like to tweak how this is displayed and reported.  Thanks!