### PR TITLE
Fixed issue where 0 counts were calculated on normalized data when th…

### DIFF
--- a/R/Maaslin2.R
+++ b/R/Maaslin2.R
@@ -950,7 +950,7 @@ Maaslin2 <-
                 fit_data$results,
                 1,
                 FUN = function(x)
-                    length(which(filtered_data_norm[, x[1]] > 0))
+                    length(which(filtered_data[, x[1]] > 0))
             )
         
         ################################


### PR DESCRIPTION


We welcome feedback and issue reporting for all bioBakery tools through our [Discourse site](https://forum.biobakery.org/c/pull-request/featurepull-request/). For users that would like to directly contribute to the [tools](https://github.com/biobakery/) we are happy to field PRs to address **bug fixes**. Please note the turn around time on our end might be a bit long to field these but that does not mean we don't value the contribution! We currently **don't** accept PRs to add **new functionality** to tools but we would be happy to receive your feedback on [Discourse](https://forum.biobakery.org/c/pull-request/featurepull-request/).

Also, we will make sure to attribute your contribution in our User’s manual(README.md) and in any associated paper Acknowledgements.


## Description
<!---   -->
Updated code base to calculate the number of 0s on filtered but not normalized data. This should fix issues where the number of non-present features were incorrectly calculated on CLR normalized data.

## Related Issue
<!---  -->
Non-present values were not being calculated correctly on CLR normalized data. See below forum post. (i.e. since CLR allows for negative values for features that have more than 0 counts the n.not.0 column was incorrect.

<!--- Please link to the issue here: -->
https://forum.biobakery.org/t/n-not-0-column-issues-with-clr-data/5826/4

## Screenshots (if appropriate):
